### PR TITLE
Do not make use of deprecated account['id']

### DIFF
--- a/lib/campact_user_service/account.rb
+++ b/lib/campact_user_service/account.rb
@@ -8,7 +8,7 @@ module CampactUserService
     end
 
     def exists?
-      account && !account["id"].nil?
+      account && !account['external_id'].nil?
     end
 
     def subscribed_to_newsletter?

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -18,7 +18,7 @@ describe CampactUserService::Account do
     it 'should return true where a valid user object is returned' do
       stub_request(:get, "https://test.com/v1/accounts/#{user_id}")
         .to_return(body: {
-          "id": "id-123"
+          "external_id": "id-123"
         }.to_json)
 
       expect(subject.exists?).to be_truthy


### PR DESCRIPTION
Using `account['id']` is a [deprecated](https://github.com/campact/weact-adapter/blob/ef1653d0f885ba5cab744af56d29c8d2931fd1b5/doc/weact.adapter.v1.0.0.yaml#L71) and will be removed. I'd suggest to make use of `account['external_id']`.